### PR TITLE
Consolidated changes for 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ uv pip install -e .
 beman-local-ci -C /path/to/repo
 
 # Run with filters
-beman-local-ci -C /path/to/repo --compiler gcc --versions 15
+beman-local-ci -C /path/to/repo --compiler gcc --cxxversions c++26
 
 # Dry run to see what would be executed
 beman-local-ci -C /path/to/repo --dry-run
@@ -27,12 +27,15 @@ beman-local-ci -C /path/to/repo -j 8 -p 4
 ## Options
 
 - `-C DIR`: Repository directory (default: current directory)
-- `-j N`: Build parallelism (default: CPU count)
-- `-p N`: Max parallel jobs (default: unlimited)
+- `-j N`: Build parallelism (default: CPU count when `-p 1`, CPU count / 2 otherwise)
+- `-p N`: Max parallel CI jobs (default: auto based on Docker memory, use `all` for unlimited)
 - `--dry-run`: Print commands without executing
 - `--verbose`: Show detailed output
-- `--compiler COMPILER`: Filter by compiler (gcc, clang)
-- `--versions V1,V2`: Filter by versions
-- `--cxxversions V1,V2`: Filter by C++ versions
+- `--compiler C1,C2`: Filter by compiler (starts a new filter group)
+- `--versions V1,V2`: Filter by compiler versions
+- `--cxxversions V1,V2`: Filter by C++ standard versions
 - `--stdlibs S1,S2`: Filter by standard libraries
 - `--tests T1,T2`: Filter by test types
+
+All filter dimensions are independent — omitted dimensions match all values.
+Multiple `--compiler` flags create OR groups; dimensions within a group are ANDed.

--- a/TESTING.md
+++ b/TESTING.md
@@ -60,7 +60,7 @@ cmake --build /build --config Debug --parallel 32 --verbose
 echo "::step::header_sets"
 cmake --build /build --config Debug --target all_verify_interface_header_sets
 echo "::step::install"
-cmake --install /build --config Debug --prefix /opt/beman.package
+cmake --install /build --config Debug --prefix /build/stagedir
 echo "::step::test"
 ctest --test-dir /build --build-config Debug --output-on-failure
 echo "::step::done"'

--- a/beman_local_ci/cli.py
+++ b/beman_local_ci/cli.py
@@ -2,11 +2,18 @@
 """Command-line interface for beman-local-ci."""
 
 import argparse
+import math
 import os
+import platform
 import sys
 from pathlib import Path
 
-from beman_local_ci.lib.docker import check_docker
+from beman_local_ci.lib.docker import (
+    check_build_cache_ownership,
+    check_docker,
+    get_docker_memory_bytes,
+    get_system_memory_bytes,
+)
 from beman_local_ci.lib.filter import filter_jobs, parse_filter_args
 from beman_local_ci.lib.matrix import get_jobs_from_repo
 from beman_local_ci.lib.runner import run_jobs
@@ -17,25 +24,31 @@ def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Run Beman CI matrix locally via Docker",
         epilog="""
-Filter syntax:
-  --compiler COMPILER       Filter by compiler (gcc, clang)
-  --versions V1,V2          Filter by compiler versions (must follow --compiler)
-  --cxxversions V1,V2       Filter by C++ versions (must follow --versions)
-  --stdlibs S1,S2           Filter by standard libraries (must follow --versions)
-  --tests T1,T2             Filter by test types (must follow --versions)
+Filter syntax (all dimensions are independent — omitted ones match all):
+  --compiler C1,C2          Filter by compiler (gcc, clang). Starts a new filter group.
+  --versions V1,V2          Filter by compiler versions
+  --cxxversions V1,V2       Filter by C++ standard versions
+  --stdlibs S1,S2           Filter by standard libraries
+  --tests T1,T2             Filter by test types
+
+  Multiple --compiler flags create OR groups. Within a group, dimensions are ANDed.
+  Flags before the first --compiler create an implicit group (all compilers).
 
 Examples:
   # Run all jobs
   beman-local-ci -C /path/to/repo
 
-  # Run only gcc 15 jobs
-  beman-local-ci -C /path/to/repo --compiler gcc --versions 15
+  # Run only gcc jobs
+  beman-local-ci -C /path/to/repo --compiler gcc
 
-  # Run clang 21 with libc++ and Debug builds
-  beman-local-ci -C /path/to/repo --compiler clang --versions 21 --stdlibs libc++ --tests Debug.Default
+  # Run only c++26 jobs (any compiler)
+  beman-local-ci -C /path/to/repo --cxxversions c++26
 
-  # Run multiple compiler/version combinations
-  beman-local-ci --compiler gcc --versions 15,14 --compiler clang --versions 21
+  # Run gcc 15 c++26 jobs
+  beman-local-ci -C /path/to/repo --compiler gcc --versions 15 --cxxversions c++26
+
+  # Run gcc 15 OR clang 21 libc++ jobs
+  beman-local-ci --compiler gcc --versions 15 --compiler clang --versions 21 --stdlibs libc++
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -54,17 +67,36 @@ Examples:
         "--jobs",
         metavar="N",
         type=int,
-        default=os.cpu_count(),
-        help="Number of parallel build jobs (default: CPU count)",
+        default=None,
+        help="Number of parallel build jobs (default: CPU count when -p 1, CPU count / 2 otherwise)",
     )
+
+    _AUTO_PARALLEL = "auto"
+
+    def parallel_type(value: str) -> int | str | None:
+        if value == "all":
+            return None
+        if value == _AUTO_PARALLEL:
+            return _AUTO_PARALLEL
+        try:
+            n = int(value)
+        except ValueError:
+            raise argparse.ArgumentTypeError(
+                f"invalid value '{value}': expected a positive integer or 'all'"
+            )
+        if n < 1:
+            raise argparse.ArgumentTypeError(
+                f"invalid value '{value}': must be at least 1"
+            )
+        return n
 
     parser.add_argument(
         "-p",
         "--parallel",
         metavar="N",
-        type=int,
-        default=None,
-        help="Maximum number of parallel CI jobs (default: unlimited)",
+        type=parallel_type,
+        default="auto",
+        help="Maximum number of parallel CI jobs (default: auto based on Docker memory, use 'all' for unlimited)",
     )
 
     parser.add_argument(
@@ -78,6 +110,12 @@ Examples:
         "-v",
         action="store_true",
         help="Show detailed output for all jobs",
+    )
+
+    parser.add_argument(
+        "--track-performance",
+        action="store_true",
+        help="Report peak CPU and memory usage for each job",
     )
 
     return parser
@@ -109,6 +147,60 @@ def main() -> int:
             check_docker()
         except RuntimeError as e:
             print(f"Error: {e}", file=sys.stderr)
+            return 1
+
+    # Resolve auto-parallelism from Docker memory.
+    GIB = 1024**3
+    MEMORY_PER_CONTAINER_GIB = 5.9
+    # Docker Desktop reserves overhead from the configured value (e.g.
+    # slider set to 12 GB → 11.67 GiB reported).  A small fudge avoids
+    # penalising users who set exactly the recommended amount.
+    DOCKER_OVERHEAD_GIB = 0.5
+
+    if args.parallel == "auto":
+        docker_mem = get_docker_memory_bytes()
+        if docker_mem is not None:
+            effective_gib = docker_mem / GIB + DOCKER_OVERHEAD_GIB
+            parallelism = max(1, math.floor(effective_gib / MEMORY_PER_CONTAINER_GIB))
+            args.parallel = parallelism
+
+            system_mem = get_system_memory_bytes()
+            if system_mem is not None:
+                epsilon = 0.5 * GIB
+                if docker_mem < system_mem * 0.75 - epsilon:
+                    # Suggest the highest parallelism reachable within
+                    # 75% of system memory.
+                    system_gib = system_mem / GIB
+                    best_p = math.floor(
+                        (system_gib * 0.75 + DOCKER_OVERHEAD_GIB)
+                        / MEMORY_PER_CONTAINER_GIB
+                    )
+                    if best_p > parallelism:
+                        needed_gib = best_p * 6
+                        msg = (
+                            f"Selected parallelism {parallelism} "
+                            f"(increase available Docker memory to "
+                            f"{needed_gib} GiB to increase default "
+                            f"parallelism to {best_p})."
+                        )
+                        if platform.system() == "Darwin":
+                            msg += "\n  Docker Desktop: Settings > Resources > Memory"
+                    else:
+                        msg = f"Selected parallelism {parallelism}."
+                    print(msg, file=sys.stderr)
+        else:
+            args.parallel = 2  # fallback when Docker memory can't be queried
+
+    # Resolve -j default now that -p is known.
+    if args.jobs is None:
+        nproc = os.cpu_count() or 1
+        args.jobs = nproc if args.parallel == 1 else max(1, nproc // 2)
+
+    # Check build cache ownership
+    if not args.dry_run:
+        cache_err = check_build_cache_ownership()
+        if cache_err:
+            print(f"Error: {cache_err}", file=sys.stderr)
             return 1
 
     # Parse filter arguments
@@ -145,6 +237,7 @@ def main() -> int:
         max_parallel=args.parallel,
         verbose=args.verbose,
         dry_run=args.dry_run,
+        track_performance=args.track_performance,
     )
 
     return exit_code

--- a/beman_local_ci/lib/docker.py
+++ b/beman_local_ci/lib/docker.py
@@ -2,6 +2,7 @@
 """Docker command construction and execution."""
 
 import json
+import os
 import platform
 import subprocess
 import tempfile
@@ -37,6 +38,30 @@ def check_docker() -> None:
         )
     except subprocess.TimeoutExpired:
         raise RuntimeError("Docker info command timed out. Is Docker daemon running?")
+
+
+def get_docker_memory_bytes() -> int | None:
+    """Return the total memory available to Docker, in bytes."""
+    try:
+        result = subprocess.run(
+            ["docker", "info", "--format", "{{.MemTotal}}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return int(result.stdout.strip())
+    except Exception:
+        pass
+    return None
+
+
+def get_system_memory_bytes() -> int | None:
+    """Return total physical memory in bytes (POSIX only)."""
+    try:
+        return os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+    except (ValueError, OSError, AttributeError):
+        return None
 
 
 def _is_macos_arm64() -> bool:
@@ -113,7 +138,7 @@ cmake --build /build --config {resolved.build_config} --parallel {jobs} --verbos
 echo "::step::header_sets"
 cmake --build /build --config {resolved.build_config} --target all_verify_interface_header_sets
 echo "::step::install"
-cmake --install /build --config {resolved.build_config} --prefix /opt/beman.package
+cmake --install /build --config {resolved.build_config} --prefix /build/stagedir
 echo "::step::test"
 ctest --test-dir /build --build-config {resolved.build_config} --output-on-failure
 echo "::step::done"
@@ -167,6 +192,8 @@ def build_docker_command(
         "docker",
         "run",
         "--rm",
+        "--user",
+        f"{os.getuid()}:{os.getgid()}",
         *platform_args,
         "-v",
         f"{repo_path}:/src:ro",
@@ -183,25 +210,68 @@ def build_docker_command(
     return cmd
 
 
-def create_build_dir(job: CIJob, base_dir: Path | None = None) -> Path:
+BUILD_CACHE_DIR = Path(tempfile.gettempdir()) / "beman-local-ci"
+
+
+def check_build_cache_ownership() -> str | None:
+    """Check that the build cache dir has no root-owned files.
+
+    Scans up to two levels deep (the job dirs and their immediate children)
+    to detect root-owned entries without walking the entire tree.
+
+    Returns None on success, or an error message string if any
+    root-owned entry is found.
+    """
+    if not BUILD_CACHE_DIR.exists():
+        return None
+
+    uid = os.getuid()
+    root_uid = 0
+
+    # Check the top-level dir itself, then job dirs (depth 1) and their
+    # immediate children (depth 2).
+    dirs_to_scan = [BUILD_CACHE_DIR]
+    for depth, parent in enumerate(dirs_to_scan):
+        try:
+            for entry in parent.iterdir():
+                try:
+                    if entry.stat().st_uid == root_uid and root_uid != uid:
+                        return (
+                            f"Build cache contains root-owned files "
+                            f"(e.g. {entry}).\n"
+                            f"Fix with: sudo rm -rf {BUILD_CACHE_DIR}"
+                        )
+                    # Queue job dirs (depth 0→1) for one more level of scanning.
+                    if depth == 0 and entry.is_dir():
+                        dirs_to_scan.append(entry)
+                except OSError:
+                    pass
+        except OSError:
+            pass
+
+    return None
+
+
+def create_build_dir(job: CIJob, repo_name: str, base_dir: Path | None = None) -> Path:
     """
     Create a unique build directory for a job.
 
     Args:
         job: The CI job
+        repo_name: Repository/project name (used as directory prefix)
         base_dir: Base directory for build dirs (default: system temp)
 
     Returns:
         Path to the created build directory
     """
     if base_dir is None:
-        base_dir = Path(tempfile.gettempdir()) / "beman-local-ci"
+        base_dir = BUILD_CACHE_DIR
 
     base_dir.mkdir(parents=True, exist_ok=True)
 
-    # Create unique dir name from job parameters
+    # Create unique dir name from repo + job parameters
     # Use sanitized names (replace special chars)
-    job_name = f"{job.compiler}-{job.version}-{job.cxxversion}-{job.stdlib}-{job.test}"
+    job_name = f"{repo_name}-{job.compiler}-{job.version}-{job.cxxversion}-{job.stdlib}-{job.test}"
     job_name = job_name.replace("/", "_").replace(" ", "_").replace(":", "_")
 
     build_dir = base_dir / job_name

--- a/beman_local_ci/lib/filter.py
+++ b/beman_local_ci/lib/filter.py
@@ -1,77 +1,68 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """CLI filter parsing and job matching."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from beman_local_ci.lib.matrix import CIJob
 
 
 @dataclass
-class VersionFilter:
-    """Filter for a specific set of compiler versions."""
+class FilterGroup:
+    """Flat filter where each dimension is independent.
 
-    versions: list[str]
+    None means "match all" for that dimension.
+    """
+
+    compilers: list[str] | None = None
+    versions: list[str] | None = None
     cxxversions: list[str] | None = None
     stdlibs: list[str] | None = None
     tests: list[str] | None = None
 
     def matches(self, job: CIJob) -> bool:
-        """Check if this version filter matches the job."""
-        # Version must match
-        if job.version not in self.versions:
+        """Check if this filter group matches the job."""
+        if self.compilers is not None and job.compiler not in self.compilers:
             return False
-
-        # Check sub-filters (None means match all)
+        if self.versions is not None and job.version not in self.versions:
+            return False
         if self.cxxversions is not None and job.cxxversion not in self.cxxversions:
             return False
-
         if self.stdlibs is not None and job.stdlib not in self.stdlibs:
             return False
-
         if self.tests is not None and job.test not in self.tests:
             return False
-
         return True
 
 
-@dataclass
-class CompilerFilter:
-    """Filter for a specific compiler."""
-
-    compiler: str
-    version_filters: list[VersionFilter] = field(default_factory=list)
-
-    def matches(self, job: CIJob) -> bool:
-        """Check if this compiler filter matches the job."""
-        # Compiler must match
-        if job.compiler != self.compiler:
-            return False
-
-        # If no version filters, match all versions
-        if not self.version_filters:
-            return True
-
-        # Check if any version filter matches
-        return any(vf.matches(job) for vf in self.version_filters)
+def _parse_comma_values(raw: str, flag: str) -> list[str]:
+    """Split comma-separated values, stripping whitespace. Error if empty."""
+    values = [v.strip() for v in raw.split(",") if v.strip()]
+    if not values:
+        raise ValueError(f"{flag} requires at least one non-empty value")
+    return values
 
 
-def parse_filter_args(args: list[str]) -> list[CompilerFilter]:
+def parse_filter_args(args: list[str]) -> list[FilterGroup]:
     """
-    Parse filter arguments into CompilerFilter objects.
+    Parse filter arguments into FilterGroup objects.
 
-    State machine parser:
-    - --compiler X: start new CompilerFilter
-    - --versions X,Y: start new VersionFilter within current compiler
-    - --cxxversions/--stdlibs/--tests: attach to current version filter
+    Rules:
+    - --compiler X,Y starts a new FilterGroup (OR boundary).
+    - --versions, --cxxversions, --stdlibs, --tests set their field on the
+      current group.
+    - If no --compiler precedes a dimension flag, an implicit group
+      (compilers=None) is created.
+    - Same flag twice in one group: last writer wins.
 
     Returns empty list if no filters specified (match all).
     """
     if not args:
         return []
 
-    filters: list[CompilerFilter] = []
-    current_compiler: CompilerFilter | None = None
-    current_version: VersionFilter | None = None
+    filters: list[FilterGroup] = []
+    current: FilterGroup | None = None
+
+    DIMENSION_FLAGS = ("--versions", "--cxxversions", "--stdlibs", "--tests")
 
     i = 0
     while i < len(args):
@@ -80,50 +71,31 @@ def parse_filter_args(args: list[str]) -> list[CompilerFilter]:
         if arg == "--compiler":
             if i + 1 >= len(args):
                 raise ValueError("--compiler requires a value")
-
-            # Start new compiler filter
-            current_compiler = CompilerFilter(compiler=args[i + 1])
-            filters.append(current_compiler)
-            current_version = None  # Reset version context
+            current = FilterGroup(
+                compilers=_parse_comma_values(args[i + 1], "--compiler")
+            )
+            filters.append(current)
             i += 2
 
-        elif arg == "--versions":
+        elif arg in DIMENSION_FLAGS:
             if i + 1 >= len(args):
-                raise ValueError("--versions requires a value")
-            if current_compiler is None:
-                raise ValueError("--versions must follow --compiler")
+                raise ValueError(f"{arg} requires a value")
+            values = _parse_comma_values(args[i + 1], arg)
 
-            # Start new version filter
-            versions = args[i + 1].split(",")
-            current_version = VersionFilter(versions=versions)
-            current_compiler.version_filters.append(current_version)
-            i += 2
+            # Create implicit group if no --compiler preceded this flag
+            if current is None:
+                current = FilterGroup()
+                filters.append(current)
 
-        elif arg == "--cxxversions":
-            if i + 1 >= len(args):
-                raise ValueError("--cxxversions requires a value")
-            if current_version is None:
-                raise ValueError("--cxxversions must follow --versions")
+            if arg == "--versions":
+                current.versions = values
+            elif arg == "--cxxversions":
+                current.cxxversions = values
+            elif arg == "--stdlibs":
+                current.stdlibs = values
+            elif arg == "--tests":
+                current.tests = values
 
-            current_version.cxxversions = args[i + 1].split(",")
-            i += 2
-
-        elif arg == "--stdlibs":
-            if i + 1 >= len(args):
-                raise ValueError("--stdlibs requires a value")
-            if current_version is None:
-                raise ValueError("--stdlibs must follow --versions")
-
-            current_version.stdlibs = args[i + 1].split(",")
-            i += 2
-
-        elif arg == "--tests":
-            if i + 1 >= len(args):
-                raise ValueError("--tests requires a value")
-            if current_version is None:
-                raise ValueError("--tests must follow --versions")
-
-            current_version.tests = args[i + 1].split(",")
             i += 2
 
         else:
@@ -132,7 +104,7 @@ def parse_filter_args(args: list[str]) -> list[CompilerFilter]:
     return filters
 
 
-def matches_filters(job: CIJob, filters: list[CompilerFilter]) -> bool:
+def matches_filters(job: CIJob, filters: list[FilterGroup]) -> bool:
     """
     Check if a job matches any of the filters.
 
@@ -144,6 +116,6 @@ def matches_filters(job: CIJob, filters: list[CompilerFilter]) -> bool:
     return any(f.matches(job) for f in filters)
 
 
-def filter_jobs(jobs: list[CIJob], filters: list[CompilerFilter]) -> list[CIJob]:
-    """Filter jobs based on CompilerFilter list."""
+def filter_jobs(jobs: list[CIJob], filters: list[FilterGroup]) -> list[CIJob]:
+    """Filter jobs based on FilterGroup list."""
     return [job for job in jobs if matches_filters(job, filters)]

--- a/beman_local_ci/lib/runner.py
+++ b/beman_local_ci/lib/runner.py
@@ -2,14 +2,123 @@
 """Parallel job execution and result reporting."""
 
 import subprocess
+import tempfile
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 
 from beman_local_ci.lib.config import resolve_config
-from beman_local_ci.lib.docker import build_docker_command, create_build_dir
+from beman_local_ci.lib.docker import (
+    BUILD_CACHE_DIR,
+    build_docker_command,
+    create_build_dir,
+)
 from beman_local_ci.lib.matrix import CIJob
+
+# Thread-safe registry of (cidfile, Popen) for every container currently running.
+# Populated by run_job; read by _kill_all_containers on Ctrl-C.
+_active_procs_lock = threading.Lock()
+_active_procs: set[tuple[Path, "subprocess.Popen[str]"]] = set()
+
+
+def _kill_all_containers() -> None:
+    """
+    SIGKILL every Docker container that is currently being tracked.
+
+    For each active job we:
+      1. Read the container ID from its --cidfile and run `docker kill -s KILL`.
+      2. Also kill the docker-CLI subprocess directly, in case the cidfile was
+         not yet written (i.e. the container had not fully started).
+    """
+    with _active_procs_lock:
+        active = list(_active_procs)
+
+    for cidfile, proc in active:
+        try:
+            cid = cidfile.read_text().strip()
+            if cid:
+                subprocess.run(
+                    ["docker", "kill", "--signal", "KILL", cid],
+                    capture_output=True,
+                    timeout=5,
+                )
+        except Exception:
+            pass
+
+
+class _StatsCollector:
+    """Polls ``docker stats`` in a background thread, tracking peak values."""
+
+    def __init__(self, cidfile: Path):
+        self.cidfile = cidfile
+        self.peak_cpu_percent = 0.0
+        self.peak_memory_mib = 0.0
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._poll, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=5)
+
+    # ── internals ─────────────────────────────────────────────────────────
+
+    def _poll(self) -> None:
+        while not self._stop.is_set():
+            try:
+                cid = self.cidfile.read_text().strip()
+                if not cid:
+                    self._stop.wait(0.5)
+                    continue
+                result = subprocess.run(
+                    [
+                        "docker",
+                        "stats",
+                        "--no-stream",
+                        "--format",
+                        "{{.CPUPerc}}\t{{.MemUsage}}",
+                        cid,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    start_new_session=True,
+                )
+                if result.returncode == 0:
+                    self._parse(result.stdout.strip())
+            except Exception:
+                pass
+            self._stop.wait(1)
+
+    def _parse(self, line: str) -> None:
+        parts = line.split("\t")
+        if len(parts) < 2:
+            return
+        try:
+            cpu = float(parts[0].rstrip("%"))
+            self.peak_cpu_percent = max(self.peak_cpu_percent, cpu)
+        except ValueError:
+            pass
+        try:
+            mem_str = parts[1].split("/")[0].strip()
+            self.peak_memory_mib = max(self.peak_memory_mib, self._parse_mem(mem_str))
+        except (ValueError, IndexError):
+            pass
+
+    @staticmethod
+    def _parse_mem(s: str) -> float:
+        """Parse a Docker memory string (e.g. '1.23GiB') to MiB."""
+        s = s.strip()
+        for suffix, factor in (("GiB", 1024), ("MiB", 1), ("KiB", 1 / 1024)):
+            if s.endswith(suffix):
+                return float(s[: -len(suffix)]) * factor
+        if s.endswith("B"):
+            return float(s[:-1]) / (1024 * 1024)
+        return 0.0
 
 
 @dataclass
@@ -21,6 +130,8 @@ class JobResult:
     duration_secs: float
     output: str
     return_code: int
+    peak_cpu_percent: float | None = None
+    peak_memory_mib: float | None = None
 
 
 def run_job(
@@ -29,6 +140,7 @@ def run_job(
     build_jobs: int,
     verbose: bool = False,
     dry_run: bool = False,
+    track_performance: bool = False,
 ) -> JobResult:
     """
     Execute a single CI job.
@@ -44,7 +156,7 @@ def run_job(
         JobResult with execution details
     """
     resolved = resolve_config(job)
-    build_dir = create_build_dir(job)
+    build_dir = create_build_dir(job, repo_name=repo_path.name)
 
     cmd = build_docker_command(job, resolved, repo_path, build_jobs, build_dir)
 
@@ -59,50 +171,96 @@ def run_job(
             return_code=0,
         )
 
+    # Create the cidfile path without actually creating the file; Docker writes
+    # the container ID to it once the container starts, and refuses to run if
+    # the file already exists.
+    tmp = tempfile.NamedTemporaryFile(suffix=".cid", delete=False)
+    cidfile = Path(tmp.name)
+    tmp.close()
+    cidfile.unlink()
+
+    # Inject --cidfile right after --rm so we can identify the container later.
+    rm_idx = cmd.index("--rm")
+    cmd = cmd[: rm_idx + 1] + ["--cidfile", str(cidfile)] + cmd[rm_idx + 1 :]
+
     start_time = time.time()
+    proc: "subprocess.Popen[str] | None" = None
+    collector: _StatsCollector | None = None
 
     try:
-        result = subprocess.run(
+        proc = subprocess.Popen(
             cmd,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=1800,  # 30 minute timeout
+            start_new_session=True,
         )
 
-        duration = time.time() - start_time
-        success = result.returncode == 0
+        with _active_procs_lock:
+            _active_procs.add((cidfile, proc))
 
-        # Combine stdout and stderr
-        output = result.stdout
-        if result.stderr:
-            output += "\n" + result.stderr
+        if track_performance:
+            collector = _StatsCollector(cidfile)
+            collector.start()
+
+        try:
+            stdout, stderr = proc.communicate(timeout=1800)  # 30 minute timeout
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stdout, stderr = proc.communicate()
+            return JobResult(
+                job=job,
+                success=False,
+                duration_secs=time.time() - start_time,
+                output="Job timed out after 30 minutes",
+                return_code=-1,
+            )
+
+        output = stdout
+        if stderr:
+            output += "\n" + stderr
+
+        peak_cpu = None
+        peak_mem = None
+        if collector is not None:
+            collector.stop()
+            peak_cpu = collector.peak_cpu_percent
+            peak_mem = collector.peak_memory_mib
+            collector = None
 
         return JobResult(
             job=job,
-            success=success,
-            duration_secs=duration,
+            success=proc.returncode == 0,
+            duration_secs=time.time() - start_time,
             output=output,
-            return_code=result.returncode,
+            return_code=proc.returncode,
+            peak_cpu_percent=peak_cpu,
+            peak_memory_mib=peak_mem,
         )
 
-    except subprocess.TimeoutExpired:
-        duration = time.time() - start_time
-        return JobResult(
-            job=job,
-            success=False,
-            duration_secs=duration,
-            output="Job timed out after 30 minutes",
-            return_code=-1,
-        )
     except Exception as e:
-        duration = time.time() - start_time
         return JobResult(
             job=job,
             success=False,
-            duration_secs=duration,
+            duration_secs=time.time() - start_time,
             output=f"Error running job: {e}",
             return_code=-1,
         )
+
+    finally:
+        if collector is not None:
+            collector.stop()
+        if proc is not None:
+            with _active_procs_lock:
+                _active_procs.discard((cidfile, proc))
+        cidfile.unlink(missing_ok=True)
+
+
+def _format_memory(mib: float) -> str:
+    """Format MiB as a human-readable string."""
+    if mib >= 1024:
+        return f"{mib / 1024:.1f} GiB"
+    return f"{mib:.0f} MiB"
 
 
 def print_job_status(result: JobResult, verbose: bool = False) -> None:
@@ -110,7 +268,14 @@ def print_job_status(result: JobResult, verbose: bool = False) -> None:
     status = "✓ PASS" if result.success else "✗ FAIL"
     duration_str = f"{result.duration_secs:.1f}s"
 
-    print(f"{status} [{duration_str}] {result.job}")
+    perf = ""
+    if result.peak_memory_mib is not None:
+        perf = (
+            f"  [peak: {_format_memory(result.peak_memory_mib)} mem, "
+            f"{result.peak_cpu_percent:.0f}% cpu]"
+        )
+
+    print(f"{status} [{duration_str}] {result.job}{perf}")
 
     if verbose or not result.success:
         # Print output for failed jobs or when verbose
@@ -133,6 +298,7 @@ def print_summary(results: list[JobResult]) -> None:
         for result in results:
             if not result.success:
                 print(f"  - {result.job}")
+        print(f"\nNote: You can clear the build cache with: rm -rf {BUILD_CACHE_DIR}")
 
 
 def run_jobs(
@@ -142,6 +308,7 @@ def run_jobs(
     max_parallel: int | None = None,
     verbose: bool = False,
     dry_run: bool = False,
+    track_performance: bool = False,
 ) -> int:
     """
     Run CI jobs in parallel.
@@ -153,9 +320,10 @@ def run_jobs(
         max_parallel: Maximum number of jobs to run in parallel (None = unlimited)
         verbose: Print detailed output
         dry_run: Print commands without executing
+        track_performance: Poll docker stats and report peak CPU/memory per job
 
     Returns:
-        Exit code: 0 if all jobs passed, 1 if any failed
+        Exit code: 0 if all passed, 1 if any failed, 130 if interrupted (Ctrl-C)
     """
     if not jobs:
         print("No jobs to run")
@@ -168,26 +336,34 @@ def run_jobs(
 
     results: list[JobResult] = []
 
-    # Use ThreadPoolExecutor for parallel execution
-    # I/O-bound tasks (waiting on Docker) benefit from threads
+    # Use ThreadPoolExecutor for parallel execution.
+    # Manage the executor manually (not as a context manager) so we can call
+    # shutdown(cancel_futures=True) on Ctrl-C without waiting for the threads.
     max_workers = max_parallel if max_parallel else len(jobs)
+    executor = ThreadPoolExecutor(max_workers=max_workers)
 
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        # Submit all jobs
-        future_to_job = {
-            executor.submit(run_job, job, repo_path, build_jobs, verbose, dry_run): job
-            for job in jobs
-        }
+    future_to_job = {
+        executor.submit(
+            run_job, job, repo_path, build_jobs, verbose, dry_run, track_performance
+        ): job
+        for job in jobs
+    }
 
-        # Process results as they complete
+    try:
         for future in as_completed(future_to_job):
             result = future.result()
             results.append(result)
             print_job_status(result, verbose)
+    except KeyboardInterrupt:
+        print("\nInterrupted — killing running containers...")
+        executor.shutdown(wait=False, cancel_futures=True)
+        _kill_all_containers()
+        # Wait for worker threads to finish now that containers are dead.
+        # Without this, the ThreadPoolExecutor atexit handler blocks on
+        # t.join() during interpreter shutdown, requiring a second Ctrl-C.
+        executor.shutdown(wait=True)
+        return 130
 
-    # Print summary
+    executor.shutdown(wait=False)
     print_summary(results)
-
-    # Return exit code
-    any_failed = any(not r.success for r in results)
-    return 1 if any_failed else 0
+    return 1 if any(not r.success for r in results) else 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Tests for CLI."""
 
+import math
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -22,8 +23,8 @@ def test_parser_defaults():
     args, _ = parser.parse_known_args([])
 
     assert args.directory == Path.cwd()
-    assert args.jobs == os.cpu_count()
-    assert args.parallel is None
+    assert args.jobs is None  # resolved after -p is known
+    assert args.parallel == "auto"
     assert args.dry_run is False
     assert args.verbose is False
 
@@ -59,6 +60,12 @@ def test_parser_parallel():
 
     args, _ = parser.parse_known_args(["--parallel", "2"])
     assert args.parallel == 2
+
+    args, _ = parser.parse_known_args(["-p", "all"])
+    assert args.parallel is None
+
+    args, _ = parser.parse_known_args(["--parallel", "all"])
+    assert args.parallel is None
 
 
 def test_parser_dry_run():
@@ -181,7 +188,7 @@ def test_main_invalid_filter(mock_get_jobs, mock_check_docker, capsys):
             "beman-local-ci",
             "-C",
             "/workspace/beman-submodules/exemplar",
-            "--versions",
+            "--bogus",
             "15",
         ],
     ):
@@ -270,3 +277,512 @@ def test_main_no_matching_jobs(mock_get_jobs, mock_check_docker, capsys):
     assert exit_code == 1
     captured = capsys.readouterr()
     assert "No jobs match" in captured.out
+
+
+# ── Auto-parallelism ─────────────────────────────────────────────────────────
+
+GIB = 1024**3
+
+
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=int(16 * GIB))
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(16 * GIB))
+def test_auto_parallelism_16gib(
+    mock_sys_mem, mock_docker_mem, mock_run_jobs, mock_get_jobs, mock_check_docker
+):
+    """16 GiB Docker memory → floor(16/5.9) = 2."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        ["beman-local-ci", "-C", "/workspace/beman-submodules/exemplar", "--dry-run"],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    call_args = mock_run_jobs.call_args
+    assert call_args.kwargs["max_parallel"] == math.floor(16 / 5.9)
+
+
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=int(32 * GIB))
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(32 * GIB))
+def test_auto_parallelism_32gib(
+    mock_sys_mem, mock_docker_mem, mock_run_jobs, mock_get_jobs, mock_check_docker
+):
+    """32 GiB Docker memory → floor(32/5.9) = 5."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        ["beman-local-ci", "-C", "/workspace/beman-submodules/exemplar", "--dry-run"],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    call_args = mock_run_jobs.call_args
+    assert call_args.kwargs["max_parallel"] == math.floor(32 / 5.9)
+
+
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=int(4 * GIB))
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(4 * GIB))
+def test_auto_parallelism_minimum_one(
+    mock_sys_mem, mock_docker_mem, mock_run_jobs, mock_get_jobs, mock_check_docker
+):
+    """Below 5.9 GiB → parallelism clamped to 1."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        ["beman-local-ci", "-C", "/workspace/beman-submodules/exemplar", "--dry-run"],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    call_args = mock_run_jobs.call_args
+    assert call_args.kwargs["max_parallel"] == 1
+
+
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch(
+    "beman_local_ci.cli.get_docker_memory_bytes",
+    return_value=int(11.67 * GIB),  # Docker Desktop "12 GB" slider → 11.67 GiB reported
+)
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(32 * GIB))
+def test_auto_parallelism_docker_desktop_overhead(
+    mock_sys_mem, mock_docker_mem, mock_run_jobs, mock_get_jobs, mock_check_docker
+):
+    """11.67 GiB (Docker Desktop '12 GB') → parallelism 2 thanks to fudge factor."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        ["beman-local-ci", "-C", "/workspace/beman-submodules/exemplar", "--dry-run"],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    call_args = mock_run_jobs.call_args
+    assert call_args.kwargs["max_parallel"] == 2
+
+
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=None)
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(32 * GIB))
+def test_auto_parallelism_docker_unavailable(
+    mock_sys_mem, mock_docker_mem, mock_run_jobs, mock_get_jobs, mock_check_docker
+):
+    """Falls back to 2 when Docker memory can't be queried."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        ["beman-local-ci", "-C", "/workspace/beman-submodules/exemplar", "--dry-run"],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    call_args = mock_run_jobs.call_args
+    assert call_args.kwargs["max_parallel"] == 2
+
+
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=int(8 * GIB))
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(64 * GIB))
+def test_auto_parallelism_warns_when_docker_memory_low(
+    mock_sys_mem,
+    mock_docker_mem,
+    mock_run_jobs,
+    mock_get_jobs,
+    mock_check_docker,
+    capsys,
+):
+    """Warns when Docker memory is well below 75% of system memory."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        ["beman-local-ci", "-C", "/workspace/beman-submodules/exemplar", "--dry-run"],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    captured = capsys.readouterr()
+    assert "Selected parallelism 1" in captured.err
+    # best_p = floor((64*0.75 + 0.5) / 5.9) = 8, needed = 8 * 6 = 48
+    assert "48 GiB" in captured.err
+    assert "parallelism to 8" in captured.err
+    assert "increase available Docker memory" in captured.err
+
+
+@patch("beman_local_ci.cli.platform")
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=int(8 * GIB))
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(64 * GIB))
+def test_auto_parallelism_warning_includes_docker_desktop_on_macos(
+    mock_sys_mem,
+    mock_docker_mem,
+    mock_run_jobs,
+    mock_get_jobs,
+    mock_check_docker,
+    mock_platform,
+    capsys,
+):
+    """Warning includes Docker Desktop navigation hint on macOS."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_platform.system.return_value = "Darwin"
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        ["beman-local-ci", "-C", "/workspace/beman-submodules/exemplar", "--dry-run"],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    captured = capsys.readouterr()
+    assert "Docker Desktop: Settings > Resources > Memory" in captured.err
+
+
+@patch("beman_local_ci.cli.platform")
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=int(8 * GIB))
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(64 * GIB))
+def test_auto_parallelism_warning_no_docker_desktop_on_linux(
+    mock_sys_mem,
+    mock_docker_mem,
+    mock_run_jobs,
+    mock_get_jobs,
+    mock_check_docker,
+    mock_platform,
+    capsys,
+):
+    """Warning omits Docker Desktop hint on Linux."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_platform.system.return_value = "Linux"
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        ["beman-local-ci", "-C", "/workspace/beman-submodules/exemplar", "--dry-run"],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    captured = capsys.readouterr()
+    assert "increase available Docker memory" in captured.err
+    assert "Docker Desktop" not in captured.err
+
+
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=int(24 * GIB))
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(32 * GIB))
+def test_auto_parallelism_no_warning_when_close_to_system(
+    mock_sys_mem,
+    mock_docker_mem,
+    mock_run_jobs,
+    mock_get_jobs,
+    mock_check_docker,
+    capsys,
+):
+    """No warning when Docker memory is >= 75% of system memory."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        ["beman-local-ci", "-C", "/workspace/beman-submodules/exemplar", "--dry-run"],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    captured = capsys.readouterr()
+    assert "increase available Docker memory" not in captured.err
+
+
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=int(16 * GIB))
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(16 * GIB))
+def test_explicit_parallel_overrides_auto(
+    mock_sys_mem, mock_docker_mem, mock_run_jobs, mock_get_jobs, mock_check_docker
+):
+    """Explicit -p value bypasses auto-detection."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        [
+            "beman-local-ci",
+            "-C",
+            "/workspace/beman-submodules/exemplar",
+            "--dry-run",
+            "-p",
+            "4",
+        ],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    call_args = mock_run_jobs.call_args
+    assert call_args.kwargs["max_parallel"] == 4
+
+
+# ── -j default depends on -p ─────────────────────────────────────────────────
+
+
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=int(4 * GIB))
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(4 * GIB))
+def test_jobs_default_nproc_when_parallel_one(
+    mock_sys_mem, mock_docker_mem, mock_run_jobs, mock_get_jobs, mock_check_docker
+):
+    """-j defaults to full CPU count when -p resolves to 1."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        ["beman-local-ci", "-C", "/workspace/beman-submodules/exemplar", "--dry-run"],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    call_args = mock_run_jobs.call_args
+    assert call_args.kwargs["max_parallel"] == 1
+    assert call_args.kwargs["build_jobs"] == (os.cpu_count() or 1)
+
+
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=int(16 * GIB))
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(16 * GIB))
+def test_jobs_default_nproc_half_when_parallel_gt_one(
+    mock_sys_mem, mock_docker_mem, mock_run_jobs, mock_get_jobs, mock_check_docker
+):
+    """-j defaults to CPU count / 2 when -p > 1."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        ["beman-local-ci", "-C", "/workspace/beman-submodules/exemplar", "--dry-run"],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    call_args = mock_run_jobs.call_args
+    assert call_args.kwargs["max_parallel"] == math.floor((16 + 0.5) / 5.9)
+    assert call_args.kwargs["build_jobs"] == max(1, (os.cpu_count() or 1) // 2)
+
+
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=int(16 * GIB))
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(16 * GIB))
+def test_jobs_default_nproc_half_when_explicit_parallel_gt_one(
+    mock_sys_mem, mock_docker_mem, mock_run_jobs, mock_get_jobs, mock_check_docker
+):
+    """-j defaults to CPU count / 2 when user passes -p 2."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        [
+            "beman-local-ci",
+            "-C",
+            "/workspace/beman-submodules/exemplar",
+            "--dry-run",
+            "-p",
+            "2",
+        ],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    call_args = mock_run_jobs.call_args
+    assert call_args.kwargs["build_jobs"] == max(1, (os.cpu_count() or 1) // 2)
+
+
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=int(16 * GIB))
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(16 * GIB))
+def test_jobs_default_nproc_when_explicit_parallel_one(
+    mock_sys_mem, mock_docker_mem, mock_run_jobs, mock_get_jobs, mock_check_docker
+):
+    """-j defaults to full CPU count when user passes -p 1."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        [
+            "beman-local-ci",
+            "-C",
+            "/workspace/beman-submodules/exemplar",
+            "--dry-run",
+            "-p",
+            "1",
+        ],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    call_args = mock_run_jobs.call_args
+    assert call_args.kwargs["build_jobs"] == (os.cpu_count() or 1)
+
+
+@patch("beman_local_ci.cli.check_docker")
+@patch("beman_local_ci.cli.get_jobs_from_repo")
+@patch("beman_local_ci.cli.run_jobs")
+@patch("beman_local_ci.cli.get_docker_memory_bytes", return_value=int(16 * GIB))
+@patch("beman_local_ci.cli.get_system_memory_bytes", return_value=int(16 * GIB))
+def test_explicit_jobs_not_overridden(
+    mock_sys_mem, mock_docker_mem, mock_run_jobs, mock_get_jobs, mock_check_docker
+):
+    """Explicit -j is never overridden regardless of -p."""
+    from beman_local_ci.lib.matrix import CIJob
+
+    mock_check_docker.return_value = None
+    mock_get_jobs.return_value = [
+        CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
+    ]
+    mock_run_jobs.return_value = 0
+
+    with patch(
+        "sys.argv",
+        [
+            "beman-local-ci",
+            "-C",
+            "/workspace/beman-submodules/exemplar",
+            "--dry-run",
+            "-p",
+            "1",
+            "-j",
+            "4",
+        ],
+    ):
+        if not Path("/workspace/beman-submodules/exemplar").exists():
+            pytest.skip("Exemplar repo not available")
+        main()
+
+    call_args = mock_run_jobs.call_args
+    assert call_args.kwargs["build_jobs"] == 4

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -2,6 +2,7 @@
 """Tests for Docker command construction."""
 
 import json
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -17,6 +18,8 @@ from beman_local_ci.lib.docker import (
     check_docker,
     create_build_dir,
     docker_image,
+    get_docker_memory_bytes,
+    get_system_memory_bytes,
 )
 from beman_local_ci.lib.matrix import CIJob
 
@@ -122,6 +125,11 @@ def test_build_docker_command():
     assert cmd[1] == "run"
     assert "--rm" in cmd
 
+    # Check --user uid:gid
+    assert "--user" in cmd
+    user_idx = cmd.index("--user")
+    assert cmd[user_idx + 1] == f"{os.getuid()}:{os.getgid()}"
+
     # Check volume mounts
     assert "-v" in cmd
     mount_indices = [i for i, x in enumerate(cmd) if x == "-v"]
@@ -152,9 +160,10 @@ def test_create_build_dir_default():
     """Test creating build directory with default base."""
     job = CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
 
-    build_dir = create_build_dir(job)
+    build_dir = create_build_dir(job, repo_name="exemplar")
 
     assert build_dir.exists()
+    assert "exemplar" in str(build_dir)
     assert "gcc" in str(build_dir)
     assert "15" in str(build_dir)
     assert build_dir.is_dir()
@@ -168,10 +177,11 @@ def test_create_build_dir_custom_base():
     job = CIJob("clang", "21", "c++26", "libc++", "Release.TSan")
     base_dir = Path(tempfile.mkdtemp())
 
-    build_dir = create_build_dir(job, base_dir=base_dir)
+    build_dir = create_build_dir(job, repo_name="execution", base_dir=base_dir)
 
     assert build_dir.exists()
     assert build_dir.parent == base_dir
+    assert "execution" in str(build_dir)
     assert "clang" in str(build_dir)
     assert "21" in str(build_dir)
 
@@ -185,7 +195,7 @@ def test_create_build_dir_sanitizes_name():
     job = CIJob("gcc", "trunk", "c++26", "libstdc++", "Debug.-DFOO=ON")
     base_dir = Path(tempfile.mkdtemp())
 
-    build_dir = create_build_dir(job, base_dir=base_dir)
+    build_dir = create_build_dir(job, repo_name="exemplar", base_dir=base_dir)
 
     # Should not contain special characters that could cause issues
     assert "/" not in build_dir.name
@@ -203,8 +213,8 @@ def test_create_build_dir_idempotent():
     job = CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
     base_dir = Path(tempfile.mkdtemp())
 
-    build_dir1 = create_build_dir(job, base_dir=base_dir)
-    build_dir2 = create_build_dir(job, base_dir=base_dir)
+    build_dir1 = create_build_dir(job, repo_name="exemplar", base_dir=base_dir)
+    build_dir2 = create_build_dir(job, repo_name="exemplar", base_dir=base_dir)
 
     assert build_dir1 == build_dir2
     assert build_dir1.exists()
@@ -416,3 +426,43 @@ def test_build_docker_command_no_platform_on_linux(mock_is_macos):
     )
 
     assert "--platform" not in cmd
+
+
+# ── Docker / system memory queries ────────────────────────────────────────────
+
+
+@patch("subprocess.run")
+def test_get_docker_memory_bytes_success(mock_run):
+    """Returns parsed integer from docker info."""
+    mock_run.return_value = MagicMock(returncode=0, stdout="16777216000\n")
+    assert get_docker_memory_bytes() == 16777216000
+
+
+@patch("subprocess.run")
+def test_get_docker_memory_bytes_failure(mock_run):
+    """Returns None when docker info fails."""
+    mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+    assert get_docker_memory_bytes() is None
+
+
+@patch("subprocess.run")
+def test_get_docker_memory_bytes_exception(mock_run):
+    """Returns None on subprocess exception."""
+    mock_run.side_effect = Exception("timeout")
+    assert get_docker_memory_bytes() is None
+
+
+@patch("os.sysconf")
+def test_get_system_memory_bytes_success(mock_sysconf):
+    """Returns page_size * page_count."""
+    mock_sysconf.side_effect = lambda key: {
+        "SC_PAGE_SIZE": 4096,
+        "SC_PHYS_PAGES": 4194304,
+    }[key]
+    assert get_system_memory_bytes() == 4096 * 4194304
+
+
+@patch("os.sysconf", side_effect=OSError("unsupported"))
+def test_get_system_memory_bytes_oserror(mock_sysconf):
+    """Returns None when sysconf is unavailable."""
+    assert get_system_memory_bytes() is None

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -4,8 +4,7 @@
 import pytest
 
 from beman_local_ci.lib.filter import (
-    CompilerFilter,
-    VersionFilter,
+    FilterGroup,
     filter_jobs,
     matches_filters,
     parse_filter_args,
@@ -26,307 +25,337 @@ def sample_jobs():
     ]
 
 
-def test_version_filter_matches_version():
-    """Test VersionFilter matches correct version."""
-    vf = VersionFilter(versions=["15"])
-    job = CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
-    assert vf.matches(job)
-
-
-def test_version_filter_rejects_wrong_version():
-    """Test VersionFilter rejects wrong version."""
-    vf = VersionFilter(versions=["15"])
-    job = CIJob("gcc", "14", "c++26", "libstdc++", "Debug.Default")
-    assert not vf.matches(job)
-
-
-def test_version_filter_multiple_versions():
-    """Test VersionFilter with multiple versions."""
-    vf = VersionFilter(versions=["15", "14"])
-    job1 = CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
-    job2 = CIJob("gcc", "14", "c++26", "libstdc++", "Debug.Default")
-    job3 = CIJob("gcc", "13", "c++26", "libstdc++", "Debug.Default")
-
-    assert vf.matches(job1)
-    assert vf.matches(job2)
-    assert not vf.matches(job3)
-
-
-def test_version_filter_with_cxxversion():
-    """Test VersionFilter with cxxversion filter."""
-    vf = VersionFilter(versions=["15"], cxxversions=["c++26"])
-    job1 = CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
-    job2 = CIJob("gcc", "15", "c++23", "libstdc++", "Debug.Default")
-
-    assert vf.matches(job1)
-    assert not vf.matches(job2)
-
-
-def test_version_filter_with_stdlib():
-    """Test VersionFilter with stdlib filter."""
-    vf = VersionFilter(versions=["21"], stdlibs=["libc++"])
-    job1 = CIJob("clang", "21", "c++26", "libc++", "Debug.Default")
-    job2 = CIJob("clang", "21", "c++26", "libstdc++", "Debug.Default")
-
-    assert vf.matches(job1)
-    assert not vf.matches(job2)
-
-
-def test_version_filter_with_test():
-    """Test VersionFilter with test filter."""
-    vf = VersionFilter(versions=["15"], tests=["Debug.Default"])
-    job1 = CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
-    job2 = CIJob("gcc", "15", "c++26", "libstdc++", "Release.TSan")
-
-    assert vf.matches(job1)
-    assert not vf.matches(job2)
-
-
-def test_version_filter_with_all_subfilters():
-    """Test VersionFilter with all sub-filters."""
-    vf = VersionFilter(
-        versions=["15"],
-        cxxversions=["c++26"],
-        stdlibs=["libstdc++"],
-        tests=["Debug.Default"],
-    )
-
-    job_match = CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
-    job_wrong_cxx = CIJob("gcc", "15", "c++23", "libstdc++", "Debug.Default")
-    job_wrong_stdlib = CIJob("gcc", "15", "c++26", "libc++", "Debug.Default")
-    job_wrong_test = CIJob("gcc", "15", "c++26", "libstdc++", "Release.TSan")
-
-    assert vf.matches(job_match)
-    assert not vf.matches(job_wrong_cxx)
-    assert not vf.matches(job_wrong_stdlib)
-    assert not vf.matches(job_wrong_test)
-
-
-def test_compiler_filter_matches_compiler():
-    """Test CompilerFilter matches correct compiler."""
-    cf = CompilerFilter(compiler="gcc")
-    job_gcc = CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
-    job_clang = CIJob("clang", "21", "c++26", "libc++", "Debug.Default")
-
-    assert cf.matches(job_gcc)
-    assert not cf.matches(job_clang)
-
-
-def test_compiler_filter_no_version_filters_matches_all():
-    """Test CompilerFilter with no version filters matches all versions."""
-    cf = CompilerFilter(compiler="gcc")
-    job1 = CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
-    job2 = CIJob("gcc", "14", "c++23", "libstdc++", "Release.TSan")
-
-    assert cf.matches(job1)
-    assert cf.matches(job2)
-
-
-def test_compiler_filter_with_version_filters():
-    """Test CompilerFilter with version filters."""
-    cf = CompilerFilter(
-        compiler="gcc", version_filters=[VersionFilter(versions=["15"])]
-    )
-
-    job1 = CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default")
-    job2 = CIJob("gcc", "14", "c++26", "libstdc++", "Debug.Default")
-
-    assert cf.matches(job1)
-    assert not cf.matches(job2)
-
-
-def test_parse_filter_args_empty():
-    """Test parsing empty filter args."""
-    filters = parse_filter_args([])
-    assert filters == []
-
-
-def test_parse_filter_args_single_compiler():
-    """Test parsing single compiler filter."""
-    filters = parse_filter_args(["--compiler", "gcc"])
-
-    assert len(filters) == 1
-    assert filters[0].compiler == "gcc"
-    assert filters[0].version_filters == []
-
-
-def test_parse_filter_args_compiler_with_versions():
-    """Test parsing compiler with versions."""
-    filters = parse_filter_args(["--compiler", "gcc", "--versions", "15,14"])
-
-    assert len(filters) == 1
-    assert filters[0].compiler == "gcc"
-    assert len(filters[0].version_filters) == 1
-    assert filters[0].version_filters[0].versions == ["15", "14"]
-
-
-def test_parse_filter_args_full_filter():
-    """Test parsing full filter with all sub-filters."""
-    filters = parse_filter_args(
-        [
-            "--compiler",
-            "gcc",
-            "--versions",
-            "15",
-            "--cxxversions",
-            "c++26,c++23",
-            "--stdlibs",
-            "libstdc++",
-            "--tests",
-            "Debug.Default",
-        ]
-    )
-
-    assert len(filters) == 1
-    cf = filters[0]
-    assert cf.compiler == "gcc"
-    assert len(cf.version_filters) == 1
-
-    vf = cf.version_filters[0]
-    assert vf.versions == ["15"]
-    assert vf.cxxversions == ["c++26", "c++23"]
-    assert vf.stdlibs == ["libstdc++"]
-    assert vf.tests == ["Debug.Default"]
-
-
-def test_parse_filter_args_multiple_compilers():
-    """Test parsing multiple compiler filters."""
-    filters = parse_filter_args(
-        ["--compiler", "gcc", "--versions", "15", "--compiler", "clang"]
-    )
-
-    assert len(filters) == 2
-    assert filters[0].compiler == "gcc"
-    assert filters[1].compiler == "clang"
-
-
-def test_parse_filter_args_multiple_version_filters():
-    """Test parsing multiple version filters for same compiler."""
-    filters = parse_filter_args(
-        [
-            "--compiler",
-            "gcc",
-            "--versions",
-            "15",
-            "--tests",
-            "Debug.Default",
-            "--versions",
-            "14",
-            "--tests",
-            "Release.TSan",
-        ]
-    )
-
-    assert len(filters) == 1
-    cf = filters[0]
-    assert cf.compiler == "gcc"
-    assert len(cf.version_filters) == 2
-
-    vf1 = cf.version_filters[0]
-    assert vf1.versions == ["15"]
-    assert vf1.tests == ["Debug.Default"]
-
-    vf2 = cf.version_filters[1]
-    assert vf2.versions == ["14"]
-    assert vf2.tests == ["Release.TSan"]
-
-
-def test_parse_filter_args_error_no_compiler_value():
-    """Test error when --compiler has no value."""
-    with pytest.raises(ValueError, match="--compiler requires a value"):
-        parse_filter_args(["--compiler"])
-
-
-def test_parse_filter_args_error_no_versions_value():
-    """Test error when --versions has no value."""
-    with pytest.raises(ValueError, match="--versions requires a value"):
-        parse_filter_args(["--compiler", "gcc", "--versions"])
-
-
-def test_parse_filter_args_error_versions_without_compiler():
-    """Test error when --versions appears before --compiler."""
-    with pytest.raises(ValueError, match="--versions must follow --compiler"):
-        parse_filter_args(["--versions", "15"])
-
-
-def test_parse_filter_args_error_cxxversions_without_versions():
-    """Test error when --cxxversions appears without --versions."""
-    with pytest.raises(ValueError, match="--cxxversions must follow --versions"):
-        parse_filter_args(["--compiler", "gcc", "--cxxversions", "c++26"])
-
-
-def test_parse_filter_args_error_unknown_arg():
-    """Test error on unknown argument."""
-    with pytest.raises(ValueError, match="Unknown filter argument"):
-        parse_filter_args(["--unknown", "value"])
-
-
-def test_matches_filters_empty_filters_matches_all(sample_jobs):
-    """Test that empty filter list matches all jobs."""
-    for job in sample_jobs:
-        assert matches_filters(job, [])
-
-
-def test_matches_filters_compiler_only(sample_jobs):
-    """Test filtering by compiler only."""
-    filters = [CompilerFilter(compiler="gcc")]
-
-    gcc_jobs = [j for j in sample_jobs if matches_filters(j, filters)]
-    assert len(gcc_jobs) == 3
-    assert all(j.compiler == "gcc" for j in gcc_jobs)
-
-
-def test_matches_filters_multiple_compilers(sample_jobs):
-    """Test filtering with multiple compilers."""
-    filters = [CompilerFilter(compiler="gcc"), CompilerFilter(compiler="clang")]
-
-    # Should match all jobs
-    matched = [j for j in sample_jobs if matches_filters(j, filters)]
-    assert len(matched) == len(sample_jobs)
-
-
-def test_matches_filters_specific_version(sample_jobs):
-    """Test filtering by specific version."""
-    filters = [
-        CompilerFilter(compiler="gcc", version_filters=[VersionFilter(versions=["15"])])
-    ]
-
-    matched = [j for j in sample_jobs if matches_filters(j, filters)]
-    assert len(matched) == 2
-    assert all(j.compiler == "gcc" and j.version == "15" for j in matched)
-
-
-def test_matches_filters_complex(sample_jobs):
-    """Test complex filter with multiple constraints."""
-    filters = [
-        CompilerFilter(
-            compiler="clang",
-            version_filters=[
-                VersionFilter(
-                    versions=["21"], stdlibs=["libc++"], tests=["Debug.Default"]
-                )
-            ],
+# ── FilterGroup.matches unit tests ──────────────────────────────────
+
+
+class TestFilterGroupMatches:
+    """Unit tests for FilterGroup.matches."""
+
+    def test_all_none_matches_everything(self):
+        fg = FilterGroup()
+        assert fg.matches(CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default"))
+
+    def test_compiler_match(self):
+        fg = FilterGroup(compilers=["gcc"])
+        assert fg.matches(CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default"))
+        assert not fg.matches(CIJob("clang", "21", "c++26", "libc++", "Debug.Default"))
+
+    def test_compiler_multi(self):
+        fg = FilterGroup(compilers=["gcc", "clang"])
+        assert fg.matches(CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default"))
+        assert fg.matches(CIJob("clang", "21", "c++26", "libc++", "Debug.Default"))
+
+    def test_versions_only(self):
+        fg = FilterGroup(versions=["15"])
+        assert fg.matches(CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default"))
+        assert not fg.matches(CIJob("gcc", "14", "c++26", "libstdc++", "Debug.Default"))
+
+    def test_cxxversions_only(self):
+        fg = FilterGroup(cxxversions=["c++26"])
+        assert fg.matches(CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default"))
+        assert not fg.matches(
+            CIJob("clang", "20", "c++23", "libc++", "Release.Default")
         )
-    ]
 
-    matched = [j for j in sample_jobs if matches_filters(j, filters)]
-    assert len(matched) == 1
-    assert matched[0].compiler == "clang"
-    assert matched[0].version == "21"
-    assert matched[0].stdlib == "libc++"
-    assert matched[0].test == "Debug.Default"
+    def test_stdlibs_only(self):
+        fg = FilterGroup(stdlibs=["libc++"])
+        assert fg.matches(CIJob("clang", "21", "c++26", "libc++", "Debug.Default"))
+        assert not fg.matches(CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default"))
+
+    def test_tests_only(self):
+        fg = FilterGroup(tests=["Debug.Default"])
+        assert fg.matches(CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default"))
+        assert not fg.matches(
+            CIJob("clang", "21", "c++26", "libstdc++", "Release.TSan")
+        )
+
+    def test_multiple_dimensions(self):
+        fg = FilterGroup(
+            compilers=["clang"],
+            versions=["21"],
+            stdlibs=["libc++"],
+            tests=["Debug.Default"],
+        )
+        assert fg.matches(CIJob("clang", "21", "c++26", "libc++", "Debug.Default"))
+        assert not fg.matches(
+            CIJob("clang", "21", "c++26", "libstdc++", "Release.TSan")
+        )
+        assert not fg.matches(CIJob("gcc", "21", "c++26", "libc++", "Debug.Default"))
+
+    def test_all_five_dimensions(self):
+        fg = FilterGroup(
+            compilers=["gcc"],
+            versions=["15"],
+            cxxversions=["c++26"],
+            stdlibs=["libstdc++"],
+            tests=["Debug.Default"],
+        )
+        assert fg.matches(CIJob("gcc", "15", "c++26", "libstdc++", "Debug.Default"))
+        assert not fg.matches(CIJob("gcc", "15", "c++23", "libstdc++", "Debug.Default"))
+        assert not fg.matches(CIJob("gcc", "15", "c++26", "libc++", "Debug.Default"))
+        assert not fg.matches(CIJob("gcc", "15", "c++26", "libstdc++", "Release.TSan"))
 
 
-def test_filter_jobs(sample_jobs):
-    """Test filter_jobs convenience function."""
-    filters = [CompilerFilter(compiler="gcc")]
-    filtered = filter_jobs(sample_jobs, filters)
-
-    assert len(filtered) == 3
-    assert all(j.compiler == "gcc" for j in filtered)
+# ── parse_filter_args tests ─────────────────────────────────────────
 
 
-def test_filter_jobs_empty_filters_returns_all(sample_jobs):
-    """Test filter_jobs with empty filters returns all jobs."""
-    filtered = filter_jobs(sample_jobs, [])
-    assert filtered == sample_jobs
+class TestParseFilterArgs:
+    """Tests for the argument parser."""
+
+    def test_empty(self):
+        assert parse_filter_args([]) == []
+
+    def test_single_compiler(self):
+        groups = parse_filter_args(["--compiler", "gcc"])
+        assert len(groups) == 1
+        assert groups[0].compilers == ["gcc"]
+        assert groups[0].versions is None
+
+    def test_compiler_with_versions(self):
+        groups = parse_filter_args(["--compiler", "gcc", "--versions", "15,14"])
+        assert len(groups) == 1
+        assert groups[0].compilers == ["gcc"]
+        assert groups[0].versions == ["15", "14"]
+
+    def test_full_filter(self):
+        groups = parse_filter_args(
+            [
+                "--compiler",
+                "gcc",
+                "--versions",
+                "15",
+                "--cxxversions",
+                "c++26,c++23",
+                "--stdlibs",
+                "libstdc++",
+                "--tests",
+                "Debug.Default",
+            ]
+        )
+        assert len(groups) == 1
+        g = groups[0]
+        assert g.compilers == ["gcc"]
+        assert g.versions == ["15"]
+        assert g.cxxversions == ["c++26", "c++23"]
+        assert g.stdlibs == ["libstdc++"]
+        assert g.tests == ["Debug.Default"]
+
+    def test_multiple_compilers_create_multiple_groups(self):
+        groups = parse_filter_args(
+            ["--compiler", "gcc", "--versions", "15", "--compiler", "clang"]
+        )
+        assert len(groups) == 2
+        assert groups[0].compilers == ["gcc"]
+        assert groups[0].versions == ["15"]
+        assert groups[1].compilers == ["clang"]
+        assert groups[1].versions is None
+
+    def test_comma_separated_compilers(self):
+        groups = parse_filter_args(["--compiler", "gcc,clang"])
+        assert len(groups) == 1
+        assert groups[0].compilers == ["gcc", "clang"]
+
+    def test_standalone_cxxversions_no_compiler(self):
+        """--cxxversions without preceding --compiler creates implicit group."""
+        groups = parse_filter_args(["--cxxversions", "c++26"])
+        assert len(groups) == 1
+        assert groups[0].compilers is None
+        assert groups[0].cxxversions == ["c++26"]
+
+    def test_standalone_versions_no_compiler(self):
+        groups = parse_filter_args(["--versions", "15"])
+        assert len(groups) == 1
+        assert groups[0].compilers is None
+        assert groups[0].versions == ["15"]
+
+    def test_standalone_stdlibs_no_compiler(self):
+        groups = parse_filter_args(["--stdlibs", "libc++"])
+        assert len(groups) == 1
+        assert groups[0].compilers is None
+        assert groups[0].stdlibs == ["libc++"]
+
+    def test_standalone_tests_no_compiler(self):
+        groups = parse_filter_args(["--tests", "Debug.Default"])
+        assert len(groups) == 1
+        assert groups[0].compilers is None
+        assert groups[0].tests == ["Debug.Default"]
+
+    def test_last_writer_wins(self):
+        """Same flag twice in one group: last value wins."""
+        groups = parse_filter_args(
+            ["--compiler", "gcc", "--versions", "15", "--versions", "14"]
+        )
+        assert len(groups) == 1
+        assert groups[0].versions == ["14"]
+
+    def test_compiler_starts_new_group_resets_dimensions(self):
+        groups = parse_filter_args(
+            [
+                "--compiler",
+                "gcc",
+                "--versions",
+                "15",
+                "--cxxversions",
+                "c++26",
+                "--compiler",
+                "clang",
+                "--cxxversions",
+                "c++23",
+            ]
+        )
+        assert len(groups) == 2
+        assert groups[0].compilers == ["gcc"]
+        assert groups[0].versions == ["15"]
+        assert groups[0].cxxversions == ["c++26"]
+        assert groups[1].compilers == ["clang"]
+        assert groups[1].versions is None
+        assert groups[1].cxxversions == ["c++23"]
+
+    def test_implicit_group_then_compiler_group(self):
+        groups = parse_filter_args(
+            ["--cxxversions", "c++26", "--compiler", "gcc", "--versions", "15"]
+        )
+        assert len(groups) == 2
+        assert groups[0].compilers is None
+        assert groups[0].cxxversions == ["c++26"]
+        assert groups[1].compilers == ["gcc"]
+        assert groups[1].versions == ["15"]
+
+
+# ── Error cases ──────────────────────────────────────────────────────
+
+
+class TestParseFilterArgsErrors:
+    """Error handling in parse_filter_args."""
+
+    def test_compiler_missing_value(self):
+        with pytest.raises(ValueError, match="--compiler requires a value"):
+            parse_filter_args(["--compiler"])
+
+    def test_versions_missing_value(self):
+        with pytest.raises(ValueError, match="--versions requires a value"):
+            parse_filter_args(["--compiler", "gcc", "--versions"])
+
+    def test_cxxversions_missing_value(self):
+        with pytest.raises(ValueError, match="--cxxversions requires a value"):
+            parse_filter_args(["--cxxversions"])
+
+    def test_stdlibs_missing_value(self):
+        with pytest.raises(ValueError, match="--stdlibs requires a value"):
+            parse_filter_args(["--stdlibs"])
+
+    def test_tests_missing_value(self):
+        with pytest.raises(ValueError, match="--tests requires a value"):
+            parse_filter_args(["--tests"])
+
+    def test_unknown_arg(self):
+        with pytest.raises(ValueError, match="Unknown filter argument"):
+            parse_filter_args(["--unknown", "value"])
+
+    def test_empty_comma_values(self):
+        with pytest.raises(ValueError, match="requires at least one non-empty value"):
+            parse_filter_args(["--compiler", ",,,"])
+
+
+# ── matches_filters / filter_jobs integration ────────────────────────
+
+
+class TestMatchesFilters:
+    """Integration tests for matches_filters and filter_jobs."""
+
+    def test_empty_filters_matches_all(self, sample_jobs):
+        for job in sample_jobs:
+            assert matches_filters(job, [])
+
+    def test_compiler_only(self, sample_jobs):
+        filters = [FilterGroup(compilers=["gcc"])]
+        gcc_jobs = [j for j in sample_jobs if matches_filters(j, filters)]
+        assert len(gcc_jobs) == 3
+        assert all(j.compiler == "gcc" for j in gcc_jobs)
+
+    def test_multiple_groups_or(self, sample_jobs):
+        filters = [
+            FilterGroup(compilers=["gcc"]),
+            FilterGroup(compilers=["clang"]),
+        ]
+        matched = [j for j in sample_jobs if matches_filters(j, filters)]
+        assert len(matched) == len(sample_jobs)
+
+    def test_specific_version(self, sample_jobs):
+        filters = [FilterGroup(compilers=["gcc"], versions=["15"])]
+        matched = [j for j in sample_jobs if matches_filters(j, filters)]
+        assert len(matched) == 2
+        assert all(j.compiler == "gcc" and j.version == "15" for j in matched)
+
+    def test_complex_filter(self, sample_jobs):
+        filters = [
+            FilterGroup(
+                compilers=["clang"],
+                versions=["21"],
+                stdlibs=["libc++"],
+                tests=["Debug.Default"],
+            )
+        ]
+        matched = [j for j in sample_jobs if matches_filters(j, filters)]
+        assert len(matched) == 1
+        assert matched[0] == CIJob("clang", "21", "c++26", "libc++", "Debug.Default")
+
+    def test_standalone_cxxversion_filter(self, sample_jobs):
+        """The motivating use case: --compiler gcc --cxxversions c++26."""
+        filters = [FilterGroup(compilers=["gcc"], cxxversions=["c++26"])]
+        matched = filter_jobs(sample_jobs, filters)
+        assert len(matched) == 3
+        assert all(j.compiler == "gcc" and j.cxxversion == "c++26" for j in matched)
+
+    def test_cxxversion_only_no_compiler(self, sample_jobs):
+        filters = [FilterGroup(cxxversions=["c++23"])]
+        matched = filter_jobs(sample_jobs, filters)
+        assert len(matched) == 1
+        assert matched[0].cxxversion == "c++23"
+
+    def test_filter_jobs_empty_filters(self, sample_jobs):
+        assert filter_jobs(sample_jobs, []) == sample_jobs
+
+    def test_filter_jobs_convenience(self, sample_jobs):
+        filters = [FilterGroup(compilers=["gcc"])]
+        filtered = filter_jobs(sample_jobs, filters)
+        assert len(filtered) == 3
+        assert all(j.compiler == "gcc" for j in filtered)
+
+
+# ── End-to-end: parse_filter_args → filter_jobs ─────────────────────
+
+
+class TestEndToEnd:
+    """Parse CLI tokens and filter jobs in one pass."""
+
+    def test_compiler_cxxversions_directly(self, sample_jobs):
+        """--compiler gcc --cxxversions c++26 (was an error before)."""
+        groups = parse_filter_args(["--compiler", "gcc", "--cxxversions", "c++26"])
+        matched = filter_jobs(sample_jobs, groups)
+        assert len(matched) == 3
+        assert all(j.compiler == "gcc" and j.cxxversion == "c++26" for j in matched)
+
+    def test_standalone_cxxversions(self, sample_jobs):
+        groups = parse_filter_args(["--cxxversions", "c++23"])
+        matched = filter_jobs(sample_jobs, groups)
+        assert len(matched) == 1
+
+    def test_two_compiler_groups(self, sample_jobs):
+        groups = parse_filter_args(
+            [
+                "--compiler",
+                "gcc",
+                "--versions",
+                "15",
+                "--compiler",
+                "clang",
+                "--versions",
+                "21",
+                "--stdlibs",
+                "libc++",
+            ]
+        )
+        matched = filter_jobs(sample_jobs, groups)
+        # gcc 15: 2 jobs; clang 21 + libc++: 1 job
+        assert len(matched) == 3


### PR DESCRIPTION
New defaults:
  - -j defaults to nproc only when building a single job, and uses nproc/2 otherwise
  - -p is automatic based on Docker memory

If your Docker memory is set to less than 75% of your system memory, it will nag you

It no longer runs containers as root, and adds a check that your build cache directory wasn't populated with root-owned files by an older version

The filters are more flexible, and no longer require a strict sequence of parameters