### PR TITLE
Typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ uv pip install -e .
 
 ```bash
 # Run all jobs for a repository
-beman-local-ci -C /path/to/repo
+uv run beman-local-ci -C /path/to/repo
 
 # Dry run to see what would be executed
-beman-local-ci -C /path/to/repo --dry-run
+uv run beman-local-ci -C /path/to/repo --dry-run
 
 # Control parallelism
-beman-local-ci -C /path/to/repo -j 8 -p 4
+uv run beman-local-ci -C /path/to/repo -j 8 -p 4
 ```
 
 ## Options


### PR DESCRIPTION
```
dariusn ~/dev/dn/git/Beman/beman-local-ci [main] $ uv pip install -e .
Using Python 3.13.8 environment at: /Users/dariusn/dev/dn/git/Beman/.venv
Resolved 2 packages in 535ms
      Built beman-local-ci @ file:///Users/dariusn/dev/dn/git/Beman/beman-local-ci
Prepared 2 packages in 448ms
Installed 2 packages in 6ms
 + beman-local-ci==0.3.0 (from file:///Users/dariusn/dev/dn/git/Beman/beman-local-ci)
 + pyyaml==6.0.3
dariusn ~/dev/dn/git/Beman/beman-local-ci [main] $ beman-local-ci -C ../beman.exemplar --dry-run
zsh: command not found: beman-local-ci
dariusn ~/dev/dn/git/Beman/beman-local-ci [main] $ ./beman-local-ci -C ../beman.exemplar --dry-run
zsh: no such file or directory: ./beman-local-ci
dariusn ~/dev/dn/git/Beman/beman-local-ci [main] $ uv run beman-local-ci -C ../beman.exemplar --dry-run
Using CPython 3.12.9 interpreter at: /opt/homebrew/opt/python@3.12/bin/python3.12
Creating virtual environment at: .venv
Installed 9 packages in 14ms
Selected parallelism 1 (increase available Docker memory to 24 GiB to increase default parallelism to 4).
  Docker Desktop: Settings > Resources > Memory
Running 67 job(s)
[DRY RUN MODE - no commands will be executed]

✓ PASS [0.0s] gcc 15 c++26 libstdc++ Debug.Default
✓ PASS [0.0s] gcc 15 c++26 libstdc++ Release.Default
✓ PASS [0.0s] gcc 15 c++26 libstdc++ Release.TSan
✓ PASS [0.0s] gcc 15 c++26 libstdc++ Release.MaxSan
✓ PASS [0.0s] gcc 15 c++26 libstdc++ Debug.Werror
✓ PASS [0.0s] gcc 15 c++26 libstdc++ Debug.Coverage
✓ PASS [0.0s] gcc 15 c++23 libstdc++ Release.Default
✓ PASS [0.0s] gcc 15 c++20 libstdc++ Release.Default
✓ PASS [0.0s] gcc 15 c++17 libstdc++ Release.Default
✓ PASS [0.0s] gcc 14 c++26 libstdc++ Release.Default
✓ PASS [0.0s] gcc 14 c++23 libstdc++ Release.Default
✓ PASS [0.0s] gcc 14 c++20 libstdc++ Release.Default
✓ PASS [0.0s] gcc 14 c++17 libstdc++ Release.Default
```