### PR TITLE
Skip header-set verification when no target opts in

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -58,7 +58,14 @@ cmake -B /build -S /src \
 echo "::step::build"
 cmake --build /build --config Debug --parallel 32 --verbose
 echo "::step::header_sets"
-cmake --build /build --config Debug --target all_verify_interface_header_sets
+verify_log=$(mktemp)
+if cmake --build /build --config Debug --target all_verify_interface_header_sets 2>&1 | tee "$verify_log"; then
+  :
+elif grep -q "unknown target.*all_verify_interface_header_sets" "$verify_log"; then
+  echo "No interface header sets to verify in this configuration; skipping."
+else
+  exit 1
+fi
 echo "::step::install"
 cmake --install /build --config Debug --prefix /build/stagedir
 echo "::step::test"

--- a/beman_local_ci/lib/docker.py
+++ b/beman_local_ci/lib/docker.py
@@ -138,7 +138,17 @@ cmake -B /build -S /src \\
 echo "::step::build"
 cmake --build /build --config {resolved.build_config} --parallel {jobs} --verbose
 echo "::step::header_sets"
-cmake --build /build --config {resolved.build_config} --target all_verify_interface_header_sets
+# all_verify_interface_header_sets only exists when at least one target sets
+# VERIFY_INTERFACE_HEADER_SETS; modules-only configurations legitimately have
+# nothing to verify. Treat ninja's "unknown target" as a skip, not a failure.
+verify_log=$(mktemp)
+if cmake --build /build --config {resolved.build_config} --target all_verify_interface_header_sets 2>&1 | tee "$verify_log"; then
+  :
+elif grep -q "unknown target.*all_verify_interface_header_sets" "$verify_log"; then
+  echo "No interface header sets to verify in this configuration; skipping."
+else
+  exit 1
+fi
 echo "::step::install"
 cmake --install /build --config {resolved.build_config} --prefix /build/stagedir
 echo "::step::test"


### PR DESCRIPTION
Mirrors the same fix made in infra-workflows: the
all_verify_interface_header_sets meta-target is only generated when at least one target sets VERIFY_INTERFACE_HEADER_SETS. Modules-only configurations have nothing to verify, and the unconditional invocation was failing such builds with "ninja: error: unknown target".